### PR TITLE
Fix lookup endpoint name when model's name has a specific plural form.

### DIFF
--- a/server/boot/admin.js
+++ b/server/boot/admin.js
@@ -564,7 +564,7 @@ module.exports.adminBoot = function adminBoot(server, userAuth, userModelName, t
 						'type': relation.type,
 						'foreignKey': relation.keyFrom,
 						'lookupProperty': relatedSchema.admin.defaultProperty,
-						'lookupEndpoint': '/api/' + relatedModel + 's/',
+						'lookupEndpoint': '/api/' + relatedSchema.plural + '/',
 						'url': related ? '/admin/views/' + relatedModel + '/' + related.id + '/view' : null,
 						'description': related ? related[relatedSchema.admin.defaultProperty] : null
 					});

--- a/server/boot/admin.js
+++ b/server/boot/admin.js
@@ -558,13 +558,14 @@ module.exports.adminBoot = function adminBoot(server, userAuth, userModelName, t
 					var related = theInstance ? theInstance[relation.name]() : [];
 					var relatedModel = relation.polymorphic ? theInstance[relation.polymorphic.discriminator] : relation.modelTo;
 					var relatedSchema = getModelInfo(relatedModel);
+					var pluralModelName = relatedSchema.plural ? relatedSchema.plural : (relatedModel + 's')
 					parents.push({
 						'name': relation.name,
 						'model': relatedModel,
 						'type': relation.type,
 						'foreignKey': relation.keyFrom,
 						'lookupProperty': relatedSchema.admin.defaultProperty,
-						'lookupEndpoint': '/api/' + relatedSchema.plural + '/',
+						'lookupEndpoint': '/api/' + pluralModelName + '/',
 						'url': related ? '/admin/views/' + relatedModel + '/' + related.id + '/view' : null,
 						'description': related ? related[relatedSchema.admin.defaultProperty] : null
 					});

--- a/server/boot/admin.js
+++ b/server/boot/admin.js
@@ -558,14 +558,14 @@ module.exports.adminBoot = function adminBoot(server, userAuth, userModelName, t
 					var related = theInstance ? theInstance[relation.name]() : [];
 					var relatedModel = relation.polymorphic ? theInstance[relation.polymorphic.discriminator] : relation.modelTo;
 					var relatedSchema = getModelInfo(relatedModel);
-					var pluralModelName = relatedSchema.plural ? relatedSchema.plural : (relatedModel + 's')
+					var relatedModelPlural = relatedSchema.plural ? relatedSchema.plural : (relatedModel + 's')
 					parents.push({
 						'name': relation.name,
 						'model': relatedModel,
 						'type': relation.type,
 						'foreignKey': relation.keyFrom,
 						'lookupProperty': relatedSchema.admin.defaultProperty,
-						'lookupEndpoint': '/api/' + pluralModelName + '/',
+						'lookupEndpoint': '/api/' + relatedModelPlural + '/',
 						'url': related ? '/admin/views/' + relatedModel + '/' + related.id + '/view' : null,
 						'description': related ? related[relatedSchema.admin.defaultProperty] : null
 					});


### PR DESCRIPTION
The issue was reported in #11 .

Now, `lookupEndpoint` will use the plural from model's definition if available.

Note, your model.json must have 'plural' defined if the plural form of name is different than adding a 's' suffix (example: Category -> Categories).